### PR TITLE
Add dotnet template folder and template project for ElmishTemplate

### DIFF
--- a/src/Avalonia.FuncUI.sln
+++ b/src/Avalonia.FuncUI.sln
@@ -15,6 +15,19 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "CounterElmishExample", "Exa
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Inspector", "Examples\Inspector\Inspector.fsproj", "{8678ED34-C054-49B2-B0C3-3B4BF7382EF4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "templates", "templates", "{AF5B0E92-D06F-4F91-B507-E9F7E2F80269}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Avalonia.FuncUI.ElmishTemplate", "Avalonia.FuncUI.ElmishTemplate", "{67D8F0E8-936D-435A-B47D-746D2DE1C6AD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{10630273-B75A-4800-97FB-F5999BE4600A}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Avalonia.FuncUI.ElmishTemplate", "templates\Avalonia.FuncUI.ElmishTemplate\content\Avalonia.FuncUI.ElmishTemplate.fsproj", "{9072F613-19A6-4E36-A9D9-A16E96DDC5E3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".template.config", ".template.config", "{01EBCC1B-12EA-46D1-8B58-DD8189C1DC84}"
+	ProjectSection(SolutionItems) = preProject
+		templates\Avalonia.FuncUI.ElmishTemplate\content\.template.config\template.json = templates\Avalonia.FuncUI.ElmishTemplate\content\.template.config\template.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +54,10 @@ Global
 		{8678ED34-C054-49B2-B0C3-3B4BF7382EF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8678ED34-C054-49B2-B0C3-3B4BF7382EF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8678ED34-C054-49B2-B0C3-3B4BF7382EF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9072F613-19A6-4E36-A9D9-A16E96DDC5E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9072F613-19A6-4E36-A9D9-A16E96DDC5E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9072F613-19A6-4E36-A9D9-A16E96DDC5E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9072F613-19A6-4E36-A9D9-A16E96DDC5E3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -48,6 +65,10 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{C62EFED5-5C78-4E5E-9894-500C75F4CDFA} = {E5F1B811-E995-4757-B8E9-C3EB4DA274EE}
 		{8678ED34-C054-49B2-B0C3-3B4BF7382EF4} = {E5F1B811-E995-4757-B8E9-C3EB4DA274EE}
+		{67D8F0E8-936D-435A-B47D-746D2DE1C6AD} = {AF5B0E92-D06F-4F91-B507-E9F7E2F80269}
+		{10630273-B75A-4800-97FB-F5999BE4600A} = {67D8F0E8-936D-435A-B47D-746D2DE1C6AD}
+		{9072F613-19A6-4E36-A9D9-A16E96DDC5E3} = {10630273-B75A-4800-97FB-F5999BE4600A}
+		{01EBCC1B-12EA-46D1-8B58-DD8189C1DC84} = {10630273-B75A-4800-97FB-F5999BE4600A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4630E817-6780-4C98-9379-EA3B45224339}

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/.template.config/template.json
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/.template.config/template.json
@@ -3,16 +3,17 @@
   "author": "Josua Jäger, Kevin Schneider",
   "classifications": [
     "Console",
+    "Avalonia",
     "UI",
     "Elmish"
   ],
-  "name": "Elmish Template for Avalonia.FuncUI v0.1.0",
+  "name": "Avalonia.FuncUI cross-plattform MVU GUI App",
   "tags": {
     "language": "F#",
     "type": "project"
   },
-  "identity": "Avalonia.FuncUI.ElmishTemplate",
-  "shortName": "avaloniaElmish",
-  "sourceName": "Avalonia.FuncUI.ElmishTemplate", // Will replace the string 'Avalonia.FuncUI.ElmishTemplate' when using dontet -n.
+  "identity": "Avalonia.FuncUI.BasicTemplate",
+  "shortName": "avalonia-mvu",
+  "sourceName": "Avalonia.FuncUI.BasicTemplate", // Will replace the string 'Avalonia.FuncUI.Basic' when using dontet -n.
   "preferNameDirectory": true
 }

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/.template.config/template.json
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/.template.config/template.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Josua Jäger, Kevin Schneider",
+  "classifications": [
+    "Console",
+    "UI",
+    "Elmish"
+  ],
+  "name": "Elmish Template for Avalonia.FuncUI v0.1.0",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "identity": "Avalonia.FuncUI.ElmishTemplate",
+  "shortName": "avaloniaElmish",
+  "sourceName": "Avalonia.FuncUI.ElmishTemplate", // Will replace the string 'Avalonia.FuncUI.ElmishTemplate' when using dontet -n.
+  "preferNameDirectory": true
+}

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/AppView.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/AppView.fs
@@ -7,7 +7,7 @@ open Avalonia.FuncUI
 open Avalonia.Layout
 
 
-module Counter =
+module CounterView =
 
     // The model holds data that you want to keep track of while the application is running
     type CounterState = {

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Avalonia.FuncUI.ElmishTemplate.fsproj
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Avalonia.FuncUI.ElmishTemplate.fsproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Lib.fs" />
+    <Compile Include="Counter.fs" />
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI" Version="0.1.3" />
+    <PackageReference Include="JaggerJo.Avalonia.FuncUI.Elmish" Version="0.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Avalonia.FuncUI.ElmishTemplate.fsproj
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Avalonia.FuncUI.ElmishTemplate.fsproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <Compile Include="Lib.fs" />
-    <Compile Include="Counter.fs" />
+    <Compile Include="AppView.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Counter.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Counter.fs
@@ -1,0 +1,60 @@
+﻿namespace CounterElmishSample
+
+open Avalonia.Controls
+open Avalonia.Media
+open Avalonia.FuncUI.Types
+open Avalonia.FuncUI
+open Avalonia.Layout
+
+type CustomControl() =
+    inherit Control()
+
+    member val Text: string = "" with get, set
+
+[<AutoOpen>]
+module ViewExt =
+    type Views with
+        static member customControl (attrs: TypedAttr<CustomControl> list): View =
+            Views.create<CustomControl>(attrs)
+
+module Counter =
+
+    type CounterState = {
+        count : int
+    }
+
+    let init = {
+        count = 0
+    }
+
+    type Msg =
+    | Increment
+    | Decrement
+
+    let update (msg: Msg) (state: CounterState) : CounterState =
+        match msg with
+        | Increment -> { state with count =  state.count + 1 }
+        | Decrement -> { state with count =  state.count - 1 }
+    
+    let view (state: CounterState) (dispatch): View =
+        Views.dockpanel [
+            Attrs.children [
+                Views.button [
+                    Attrs.dockPanel_dock Dock.Bottom
+                    Attrs.onClick (fun sender args -> dispatch Decrement)
+                    Attrs.content "-"
+                ]
+                Views.button [
+                    Attrs.dockPanel_dock Dock.Bottom
+                    Attrs.onClick (fun sender args -> dispatch Increment)
+                    Attrs.content "+"
+                ]
+                Views.textBlock [
+                    Attrs.dockPanel_dock Dock.Top
+                    Attrs.fontSize 48.0
+                    Attrs.verticalAlignment VerticalAlignment.Center
+                    Attrs.horizontalAlignment HorizontalAlignment.Center
+                    Attrs.text (string state.count)
+                ]
+            ]
+        ]       

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Counter.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Counter.fs
@@ -19,8 +19,6 @@ module Counter =
         count = 0
     }
 
-
-
     // The Msg type defines what events/actions can occur while the application is running
     // the state of the application changes *only* in reaction to these events
     type Msg =

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Counter.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Counter.fs
@@ -6,16 +6,6 @@ open Avalonia.FuncUI.Types
 open Avalonia.FuncUI
 open Avalonia.Layout
 
-type CustomControl() =
-    inherit Control()
-
-    member val Text: string = "" with get, set
-
-[<AutoOpen>]
-module ViewExt =
-    type Views with
-        static member customControl (attrs: TypedAttr<CustomControl> list): View =
-            Views.create<CustomControl>(attrs)
 
 module Counter =
 

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Counter.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Counter.fs
@@ -9,23 +9,31 @@ open Avalonia.Layout
 
 module Counter =
 
+    // The model holds data that you want to keep track of while the application is running
     type CounterState = {
         count : int
     }
 
-    let init = {
+    //The initial state of of the application
+    let initialState = {
         count = 0
     }
 
+
+
+    // The Msg type defines what events/actions can occur while the application is running
+    // the state of the application changes *only* in reaction to these events
     type Msg =
     | Increment
     | Decrement
 
+    // The update function computes the next state of the application based on the current state and the incoming messages
     let update (msg: Msg) (state: CounterState) : CounterState =
         match msg with
         | Increment -> { state with count =  state.count + 1 }
         | Decrement -> { state with count =  state.count - 1 }
     
+    // The view function returns the view of the application depending on its current state. Messages can be passed to the dispatch function.
     let view (state: CounterState) (dispatch): View =
         Views.dockpanel [
             Attrs.children [

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Lib.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Lib.fs
@@ -1,0 +1,13 @@
+﻿namespace CounterElmishSample
+
+[<AutoOpen>]
+module AvaloniaExtensions =
+    open Avalonia.Markup.Xaml.Styling
+    open System
+    open Avalonia.Styling
+
+    type Styles with
+        member this.Load (source: string) = 
+            let style = new StyleInclude(baseUri = null)
+            style.Source <- new Uri(source)
+            this.Add(style)

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
@@ -38,7 +38,7 @@ module Program =
         let mainWindow = MainWindow()
 
         //Create an elmish MVU program using an initial model, update function and view
-        Elmish.Program.mkSimple (fun () -> Counter.initialState) Counter.update Counter.view
+        Elmish.Program.mkSimple (fun () -> CounterView.initialState) CounterView.update CounterView.view
         |> Program.withHost mainWindow
         |> Program.withConsoleTrace
         |> Program.run

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
@@ -38,7 +38,7 @@ module Program =
         let mainWindow = MainWindow()
 
         //Create an elmish MVU program using an initial model, update function and view
-        Elmish.Program.mkSimple (fun () -> Counter.init) Counter.update Counter.view
+        Elmish.Program.mkSimple (fun () -> Counter.initialState) Counter.update Counter.view
         |> Program.withHost mainWindow
         |> Program.withConsoleTrace
         |> Program.run

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
@@ -1,0 +1,59 @@
+﻿namespace CounterElmishSample
+
+open Avalonia.FuncUI.Hosts
+open Avalonia
+open Avalonia.FuncUI.Elmish
+open Elmish
+
+type MainWindow() =
+    inherit HostWindow()
+
+    do
+        base.Title <- "Counter Elmish"
+        base.Height <- 400.0
+        base.Width <- 400.0    
+      
+        //this.VisualRoot.VisualRoot.Renderer.DrawFps <- true
+        //this.VisualRoot.VisualRoot.Renderer.DrawDirtyRects <- true
+        ()
+
+type App() =
+    inherit Application()
+
+    override this.Initialize() =
+        this.Styles.Load "resm:Avalonia.Themes.Default.DefaultTheme.xaml?assembly=Avalonia.Themes.Default"
+        this.Styles.Load "resm:Avalonia.Themes.Default.Accents.BaseDark.xaml?assembly=Avalonia.Themes.Default"
+
+module Program =
+    open Avalonia
+    open Avalonia.Logging.Serilog
+
+    // Avalonia configuration, don't remove; also used by visual designer.
+    [<CompiledName "BuildAvaloniaApp">]
+    let buildAvaloniaApp() =
+        AppBuilder
+            .Configure<App>()
+            .UsePlatformDetect()
+            .LogToDebug()
+
+    // Your application's entry point.
+    [<CompiledName "AppMain">]
+    let appMain (app: Application) (args: string[]) =
+        let mainWindow = MainWindow()
+
+        Elmish.Program.mkSimple (fun () -> Counter.init) Counter.update Counter.view
+        |> Program.withHost mainWindow
+        |> Program.withConsoleTrace
+        |> Program.run
+
+        app.Run(mainWindow)
+        |> ignore
+
+    // Initialization code. Don't use any Avalonia, third-party APIs or any
+    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+    // yet and stuff might break.
+    [<EntryPoint>]
+    [<CompiledName "Main">]
+    let main(args: string[]) =
+        buildAvaloniaApp().Start(appMain, args)
+        0

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
@@ -5,6 +5,7 @@ open Avalonia
 open Avalonia.FuncUI.Elmish
 open Elmish
 
+//The main window of your application. You can style the window by changing properties of its base (As shown below with the window title).
 type MainWindow() =
     inherit HostWindow()
 
@@ -36,6 +37,7 @@ module Program =
     let appMain (app: Application) (args: string[]) =
         let mainWindow = MainWindow()
 
+        //Create an elmish MVU program using an initial model, update function and view
         Elmish.Program.mkSimple (fun () -> Counter.init) Counter.update Counter.view
         |> Program.withHost mainWindow
         |> Program.withConsoleTrace

--- a/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
+++ b/src/templates/Avalonia.FuncUI.ElmishTemplate/content/Main.fs
@@ -9,12 +9,7 @@ type MainWindow() =
     inherit HostWindow()
 
     do
-        base.Title <- "Counter Elmish"
-        base.Height <- 400.0
-        base.Width <- 400.0    
-      
-        //this.VisualRoot.VisualRoot.Renderer.DrawFps <- true
-        //this.VisualRoot.VisualRoot.Renderer.DrawDirtyRects <- true
+        base.Title <- "Avalonia.FuncUI Counter Elmish template"
         ()
 
 type App() =


### PR DESCRIPTION
This PR contains the minimum structure for a dotnet template. I used the elmish project from the examples folder to setup this template. You still would have to install it locally at this point though. The next steps should be improving on this template and then publishing it via nuget so you can directly install it from the web.

Screenshot of me installing the template from the project folder:

![image](https://user-images.githubusercontent.com/21338071/60974251-0e935000-a32a-11e9-9633-f0c848b55a11.png)

Creating the project:

![image](https://user-images.githubusercontent.com/21338071/60974489-734eaa80-a32a-11e9-9fed-a94d5c14acfd.png)


Running the counter example after successfully building it:
![image](https://user-images.githubusercontent.com/21338071/60974634-b446bf00-a32a-11e9-94c3-1c6a48c7a4d9.png)

